### PR TITLE
fix: load configuration relative to module

### DIFF
--- a/ConfigurationHelper.py
+++ b/ConfigurationHelper.py
@@ -1,11 +1,23 @@
-# Importar el módulo json para trabajar con archivos JSON
+# Importar los módulos necesarios para trabajar con archivos JSON y rutas
 import json
+import os
+
 
 # Definir una función para obtener la configuración desde un archivo JSON
 def get_configuration():
-    # Abrir el archivo 'config.json' en modo lectura
-    with open('config.json') as config_file:
+    """Lee y devuelve la configuración del archivo ``config.json``.
+
+    Se usa una ruta basada en la ubicación del módulo para evitar errores
+    cuando el programa se ejecuta desde distintos directorios.
+    """
+
+    # Obtener la ruta absoluta del archivo de configuración
+    config_path = os.path.join(os.path.dirname(__file__), 'config.json')
+
+    # Abrir el archivo en modo lectura con la codificación adecuada
+    with open(config_path, encoding='utf-8') as config_file:
         # Cargar los datos del archivo JSON en una estructura de datos de Python
         data = json.load(config_file)
-        # Devolver los datos cargados como resultado de la función
-        return data
+
+    # Devolver los datos cargados como resultado de la función
+    return data


### PR DESCRIPTION
## Summary
- load configuration file using path relative to module to avoid missing file errors

## Testing
- `python -m py_compile ConfigurationHelper.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e67f94ca4832d98669fdfab644244